### PR TITLE
Implement basic account creation with category

### DIFF
--- a/lib/database/database_helper.dart
+++ b/lib/database/database_helper.dart
@@ -23,8 +23,9 @@ class DatabaseHelper {
     final path = join(dbPath, 'investment.db');
     return openDatabase(
       path,
-      version: 1,
+      version: 2,
       onCreate: _onCreate,
+      onUpgrade: _onUpgrade,
     );
   }
 
@@ -34,6 +35,7 @@ class DatabaseHelper {
         id INTEGER PRIMARY KEY AUTOINCREMENT,
         name TEXT,
         currency TEXT,
+        category TEXT,
         note TEXT
       )
     ''');
@@ -68,6 +70,12 @@ class DatabaseHelper {
     ''');
   }
 
+  Future _onUpgrade(Database db, int oldVersion, int newVersion) async {
+    if (oldVersion < 2) {
+      await db.execute('ALTER TABLE accounts ADD COLUMN category TEXT');
+    }
+  }
+
   Future<int> insertAccount(InvestmentAccount account) async {
     final db = await database;
     return db.insert('accounts', account.toMap());
@@ -77,6 +85,17 @@ class DatabaseHelper {
     final db = await database;
     final result = await db.query('accounts');
     return result.map((e) => InvestmentAccount.fromMap(e)).toList();
+  }
+
+  Future<int> updateAccount(InvestmentAccount account) async {
+    final db = await database;
+    return db.update('accounts', account.toMap(),
+        where: 'id = ?', whereArgs: [account.id]);
+  }
+
+  Future<int> deleteAccount(int id) async {
+    final db = await database;
+    return db.delete('accounts', where: 'id = ?', whereArgs: [id]);
   }
 
   Future<int> insertInvestment(Investment investment) async {

--- a/lib/model/investment_account.dart
+++ b/lib/model/investment_account.dart
@@ -3,14 +3,16 @@
 
 class InvestmentAccount {
   final int id;
-  final String name;       // 帳戶名稱（例如：台幣證券帳戶）
-  final String currency;   // 幣別（例如：TWD, USD, JPY）
-  final String? note;      // 備註
+  final String name; // 帳戶名稱（例如：台幣證券帳戶）
+  final String currency; // 幣別（例如：TWD, USD, JPY）
+  final String category; // 帳戶類別（美股、台股、other）
+  final String? note; // 備註
 
   InvestmentAccount({
     required this.id,
     required this.name,
     required this.currency,
+    required this.category,
     this.note,
   });
 
@@ -18,12 +20,14 @@ class InvestmentAccount {
     int? id,
     String? name,
     String? currency,
+    String? category,
     String? note,
   }) {
     return InvestmentAccount(
       id: id ?? this.id,
       name: name ?? this.name,
       currency: currency ?? this.currency,
+      category: category ?? this.category,
       note: note ?? this.note,
     );
   }
@@ -33,6 +37,7 @@ class InvestmentAccount {
       'id': id,
       'name': name,
       'currency': currency,
+      'category': category,
       'note': note,
     };
   }
@@ -42,6 +47,7 @@ class InvestmentAccount {
       id: map['id'] as int,
       name: map['name'] as String,
       currency: map['currency'] as String,
+      category: map['category'] as String,
       note: map['note'] as String?,
     );
   }

--- a/lib/view/home/HomePage.dart
+++ b/lib/view/home/HomePage.dart
@@ -45,12 +45,6 @@ class _HomePageState extends State<HomePage> {
 
   Future<void> _loadInvestments() async {
     var accounts = await _db.getAccounts();
-    if (accounts.isEmpty) {
-      await _db.insertAccount(
-          InvestmentAccount(id: 0, name: 'TWD 證券帳戶', currency: 'TWD'));
-      await _db.insertAccount(
-          InvestmentAccount(id: 0, name: 'USD 經紀帳戶', currency: 'USD'));
-    }
 
     final data = await _db.getInvestments(1);
     setState(() {


### PR DESCRIPTION
## Summary
- add `category` field to `InvestmentAccount`
- migrate database to store account category and expose update/delete methods
- remove default account seeding and add a dialog to create accounts

## Testing
- `dart --version` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68464f5f29b0832fb9b70c25b950d71b